### PR TITLE
Unread logs can be filtered

### DIFF
--- a/bp/templates/bp/index.html
+++ b/bp/templates/bp/index.html
@@ -35,9 +35,9 @@
                 <p class="card-text">
                     {{ projects_without_recent_logs_count }} Projekt{{ projects_without_recent_logs_count|pluralize:"e" }} haben keine Logs aus den letzten {{ log_period }} Tagen
                 </p>
-                <a href="{% url "bp:log_list" %}" class="btn btn-secondary">Alle Logs</a>
-                <a href="{% url "bp:log_list_unread" %}" class="btn btn-secondary">Ungelesen <span class="badge rounded-pill bg-info text-white font-weight-bold">{{ logs_unread_count }}</span></a>
-                <a href="{% url "bp:log_list_attention" %}" class="btn btn-secondary">Besondere Aufmerksamkeit <span class="badge rounded-pill bg-info text-white font-weight-bold">{{ logs_attention_count }}</span></a>
+                <a href="{% url "bp:log_list" %}" class="btn btn-secondary mb-1">Alle Logs</a>
+                <a href="{% url "bp:log_list_unread" %}" class="btn btn-secondary mb-1">Ungelesen <span class="badge rounded-pill bg-info text-white font-weight-bold">{{ logs_unread_count }}</span></a>
+                <a href="{% url "bp:log_list_attention" %}" class="btn btn-secondary mb-1">Besondere Aufmerksamkeit <span class="badge rounded-pill bg-info text-white font-weight-bold">{{ logs_attention_count }}</span></a>
             </div>
         </div>
 

--- a/bp/templates/bp/index.html
+++ b/bp/templates/bp/index.html
@@ -35,7 +35,8 @@
                 <p class="card-text">
                     {{ projects_without_recent_logs_count }} Projekt{{ projects_without_recent_logs_count|pluralize:"e" }} haben keine Logs aus den letzten {{ log_period }} Tagen
                 </p>
-                <a href="{% url "bp:log_list" %}" class="btn btn-secondary">Alle Logs <span class="badge rounded-pill bg-info text-white font-weight-bold">{{ logs_unread_count }}</span></a>
+                <a href="{% url "bp:log_list" %}" class="btn btn-secondary">Alle Logs</a>
+                <a href="{% url "bp:log_list_unread" %}" class="btn btn-secondary">Ungelesen <span class="badge rounded-pill bg-info text-white font-weight-bold">{{ logs_unread_count }}</span></a>
                 <a href="{% url "bp:log_list_attention" %}" class="btn btn-secondary">Besondere Aufmerksamkeit <span class="badge rounded-pill bg-info text-white font-weight-bold">{{ logs_attention_count }}</span></a>
             </div>
         </div>

--- a/bp/templates/bp/log_overview.html
+++ b/bp/templates/bp/log_overview.html
@@ -12,6 +12,7 @@
 {% block content %}
     <div class="float-right">
         <a class="btn btn-primary" href="{% url "bp:log_list" %}">Alle</a>
+        <a class="btn btn-warning" href="{% url "bp:log_list_unread" %}">{% fa5_icon "filter" "fas" %} Ungelesen</a>
         <a class="btn btn-warning" href="{% url "bp:log_list_attention" %}">{% fa5_icon "filter" "fas" %} Aufmerksamkeit nötig</a>
         <a class="btn btn-info" href="{% url "bp:log_remind" %}">{% fa5_icon "clock" "fas" %} Fehlende Logs</a>
     </div>

--- a/bp/urls.py
+++ b/bp/urls.py
@@ -3,7 +3,7 @@ from django.views.generic import TemplateView
 
 from bp.views import IndexView, ProjectListView, ProjectView, TLView, TLListView, AGGradeView, AGGradeSuccessView, \
     ProjectImportView, StudentListView, StudentImportView, grade_export_view, LogTLOverview, LogTLCreateView, \
-    LogTLUpdateView, LogTLDeleteView, LogListView, LogView, LogAttentionListView, APILogMarkReadView, \
+    LogTLUpdateView, LogTLDeleteView, LogListView, LogView, LogAttentionListView, LogUnreadListView, APILogMarkReadView, \
     APILogMarkHandledView, APILogMarkGoodView, APILogMarkBadView, LogReminderView, LogTLDetailView, LoginView
 
 app_name = "bp"
@@ -18,6 +18,7 @@ urlpatterns = [
     path('tl/<pk>/', TLView.as_view(), name="tl_detail"),
     path('logs/', LogListView.as_view(), name='log_list'),
     path('logs/attention/', LogAttentionListView.as_view(), name='log_list_attention'),
+    path('logs/unread/', LogUnreadListView.as_view(), name='log_list_unread'),
     path('logs/remind/', LogReminderView.as_view(), name='log_remind'),
     path('logs/<pk>/', LogView.as_view(), name='log_detail'),
     path('logs/<pk>/read/', APILogMarkReadView.as_view(), name='log_api_mark_read'),

--- a/bp/views.py
+++ b/bp/views.py
@@ -148,6 +148,15 @@ class LogAttentionListView(LogListView):
     def get_queryset(self):
         return super().get_queryset().filter(requires_attention=True)
 
+class LogUnreadListView(LogListView):
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["page_title"] = "Logs (Ungelesen)"
+        return context
+
+    def get_queryset(self):
+        return super().get_queryset().filter(read=False)
+
 
 class LogView(PermissionRequiredMixin, DetailView):
     model = TLLog


### PR DESCRIPTION
The new page under logs/unread/ only shows unread logs

The log section of the overview now lists the number of unread logs on the button for the filter instead of the general button to all logs

Solves #16