### PR TITLE
Correct last migration

### DIFF
--- a/bp/migrations/0014_reminder.py
+++ b/bp/migrations/0014_reminder.py
@@ -21,7 +21,8 @@ class Migration(migrations.Migration):
                 ('tl', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='bp.tl')),
             ],
             options={
-                'verbose_name': 'TL-Log-Erinnerungen',
+                'verbose_name': 'TL-Log-Erinnerung',
+                'verbose_name_plural': 'TL-Log-Erinnerungen'
             },
         ),
     ]


### PR DESCRIPTION
Add meta data changes for TLLogReminder that were seemingly missed at the last migration

See also #30 