### PR TITLE
Control shown content based on role

### DIFF
--- a/bp/templates/bp/base.html
+++ b/bp/templates/bp/base.html
@@ -26,7 +26,7 @@
 <body>
     <div class="container" style="margin-top:15px;margin-bottom: 30px;">
         {% block navbar_breadcrumbs %}
-            {% include "bp/navbar.html" %}
+            {% include "bp/control_navbar.html" %}
             <ol class="breadcrumb">
                 {% block breadcrumbs %}
                     <li class="breadcrumb-item active">Übersicht</li>

--- a/bp/templates/bp/base_control.html
+++ b/bp/templates/bp/base_control.html
@@ -1,0 +1,21 @@
+{% if request.user.is_anonymous %}
+    {% block shown_block_to_anonymous_user %}
+    {% endblock %}
+{% else %}
+    {% if request.user.tl and request.user.tl.confirmed %}
+        {% block shown_block_to_confirmed_tl %}
+        {% endblock %}
+    {% elif request.user.tl %}
+        {% block shown_block_to_unconfirmed_tl %}
+        {% endblock %}
+    {% elif request.user.student %}
+        {% block shown_block_to_student %}
+        {% endblock %}
+    {% elif request.user.is_superuser %}
+        {% block shown_block_to_orga %}
+        {% endblock %}
+    {% else %}
+        {% block shown_block_if_error %}
+        {% endblock %}
+    {% endif %}
+{% endif %}

--- a/bp/templates/bp/base_tl.html
+++ b/bp/templates/bp/base_tl.html
@@ -9,7 +9,7 @@
     </nav>
     <ol class="breadcrumb">
         {% block breadcrumbs %}
-            <li class="breadcrumb-item active">TL Log</li>
+            <li class="breadcrumb-item"><a href="{% url "bp:index" %}">Übersicht</a></li>
         {% endblock %}
     </ol>
 {% endblock %}
@@ -22,11 +22,21 @@
             </div>
         {% else %}
             {% if request.user.tl and request.user.tl.confirmed %}
-                <h3 class="mb-4">Hallo {{ request.user.tl.name }} <a class="btn btn-info" href="{% url "bp:log_tl_start" %}">{% fa5_icon "level-up-alt" "fas" %}</a></h3>
-
-                {% block tl_content %}{% endblock %}
-            {% else %}
+                {% block tl_content %}
+                    <h3 class="mb-4">Hallo {{ request.user.tl.name }} <a class="btn btn-info" href="{% url "bp:index" %}">{% fa5_icon "level-up-alt" "fas" %}</a></h3>
+                {% endblock %}
+            {% elif request.user.tl %}
                 <h2>Eine Bestätigung des Zugangs als TL durch das Orgateam steht noch aus.</h2>
+            {% elif request.user.student %}
+                {% block student_content %}
+                    <h3 class="mb-4">Hallo {{ request.user.student.name }} <a class="btn btn-info" href="{% url "bp:index" %}">{% fa5_icon "level-up-alt" "fas" %}</a></h3>
+                {% endblock %}
+            {% elif request.user.is_superuser %}
+                {% block orga_content %}
+                    <h3 class="mb-4">Hallo {{request.user.first_name}} {{request.user.last_name}} <a class="btn btn-info" href="{% url "bp:index" %}">{% fa5_icon "level-up-alt" "fas" %}</a></h3>
+                {% endblock %}
+            {% else %}
+                <h2>Ein Fehler ist aufgetreten.</h2>
             {% endif %}
         {% endif %}
     </div>

--- a/bp/templates/bp/base_tl.html
+++ b/bp/templates/bp/base_tl.html
@@ -2,16 +2,8 @@
 
 {% load fontawesome_5 %}
 
-{% block navbar_breadcrumbs %}
-    <nav class="navbar navbar-expand-lg navbar-dark bg-primary">
-      <a class="navbar-brand" href="#">BP Tool</a>
-      {{request.user.first_name}} {{request.user.last_name}} ({{request.user.username}})
-    </nav>
-    <ol class="breadcrumb">
-        {% block breadcrumbs %}
-            <li class="breadcrumb-item"><a href="{% url "bp:index" %}">Übersicht</a></li>
-        {% endblock %}
-    </ol>
+{% block breadcrumbs %}
+    <li class="breadcrumb-item"><a href="{% url "bp:index" %}">Übersicht</a></li>
 {% endblock %}
 
 {% block content %}

--- a/bp/templates/bp/control_navbar.html
+++ b/bp/templates/bp/control_navbar.html
@@ -1,0 +1,30 @@
+{% extends "bp/base_control.html" %}
+
+{% load fontawesome_5 %}
+
+{% block shown_block_to_anonymous_user %}
+{% block shown_block_to_unconfirmed_tl %}
+{% block shown_block_if_error %}
+{% endblock %}
+{% endblock %}
+{% endblock %}
+
+{% block shown_block_to_confirmed_tl %}
+    <nav class="navbar navbar-expand-lg navbar-dark bg-primary">
+      <a class="navbar-brand" href="#">BP Tool</a>
+      {{request.user.first_name}} {{request.user.last_name}} ({{request.user.username}})
+    </nav>
+{% endblock %}
+
+
+{% block shown_block_to_student %}
+    <nav class="navbar navbar-expand-lg navbar-dark bg-primary">
+      <a class="navbar-brand" href="#">BP Tool</a>
+      {{request.user.first_name}} {{request.user.last_name}} ({{request.user.username}})
+    </nav>
+{% endblock %}
+
+{% block shown_block_to_orga %}
+    {% include "bp/navbar.html" %}
+{% endblock %}
+

--- a/bp/templates/bp/log_tl_overview.html
+++ b/bp/templates/bp/log_tl_overview.html
@@ -1,5 +1,12 @@
 {% extends "bp/base_tl.html" %}
 
+{% load fontawesome_5 %}
+
+{% block breadcrumbs %}
+    <li class="breadcrumb-item"><a href="{% url "bp:index" %}">Übersicht</a></li>
+    <li class="breadcrumb-item active">TL Log</li>
+{% endblock %}
+
 {% block tl_content %}
     <p>Logs anzeigen und eintragen:</p>
 


### PR DESCRIPTION
Some websites are going to be shared between TLs, students and the Orga team.
The shown content can be selected based on tl_content, student_content and orga_content.

For the Log Overview, the breadcrumbs were implemented correctly, the other TL sites have to be updated
The breadcrumbs shall replace the current "Hallo XY" with a button to the Log Overview

While this approach makes the logic behind the different view content clearer, the access rules for the views should also be enforced in the view logic itself (i.e. the get method). That is to be done in a different PR