### PR TITLE
Re-linearize migration graph

### DIFF
--- a/bp/migrations/0016_add_user_to_student.py
+++ b/bp/migrations/0016_add_user_to_student.py
@@ -9,7 +9,7 @@ class Migration(migrations.Migration):
 
     dependencies = [
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
-        ('bp', '0015_aggrades_restructure'),
+        ('bp', '0016_orgalog'),
     ]
 
     operations = [


### PR DESCRIPTION
The most recent merges introduced independent migrations, which causes issues for Django.
In particular, `migrate` and `makemigrations` refuse to do anything.
Therefore, this PR linearizes the graph so that Django is happy again.