### PR TITLE
Create TLs on login

### DIFF
--- a/bp/models.py
+++ b/bp/models.py
@@ -144,13 +144,6 @@ class TL(models.Model):
         return self.name
 
 
-@receiver(post_save, sender=User)
-def update_profile_signal(sender, instance: User, created, **kwargs):
-    if created:
-        TL.objects.create(user=instance, name=f"{instance.first_name} {instance.last_name}", bp=BP.get_active(),
-                          confirmed=False)
-
-
 class AGGrade(models.Model):
     class Meta:
         abstract = True

--- a/bptool/lti/urls.py
+++ b/bptool/lti/urls.py
@@ -1,4 +1,4 @@
-"""bptool URL Configuration
+"""lti URL Configuration
 
 The `urlpatterns` list routes URLs to views. For more information please see:
     https://docs.djangoproject.com/en/3.1/topics/http/urls/
@@ -13,22 +13,8 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
-from django.contrib import admin
 from django.urls import path, re_path, include
-import debug_toolbar
 
-from .lti.urls import lti_patterns
-
-
-handler404 = 'bp.views.error_404'
-handler500 = 'bp.views.error_500'
-handler403 = 'bp.views.error_403'
-handler400 = 'bp.views.error_400'
-
-
-urlpatterns = [
-    path('admin/', admin.site.urls),
-    re_path(r'^lti/', include(lti_patterns)),
-    path('', include('bp.urls', namespace='bp')),
-    path('__debug__/', include(debug_toolbar.urls)),
+lti_patterns = [
+    re_path(r'', include('lti_provider.urls')),
 ]

--- a/bptool/lti/urls.py
+++ b/bptool/lti/urls.py
@@ -15,6 +15,9 @@ Including another URLconf
 """
 from django.urls import path, re_path, include
 
+from .views import TLRoutingView
+
 lti_patterns = [
     re_path(r'', include('lti_provider.urls')),
+    path('log', TLRoutingView.as_view()),
 ]

--- a/bptool/lti/views.py
+++ b/bptool/lti/views.py
@@ -1,0 +1,13 @@
+from lti_provider.views import LTIRoutingView
+
+from bp.views import BP, TL
+
+class TLRoutingView(LTIRoutingView):
+    def dispatch(self, request, *args, **kwargs):
+        response = super().dispatch(request, *args, **kwargs)
+        # Login happens in dispatch above
+        instance = request.user
+        if instance and not TL.objects.filter(user=instance).first():
+            TL.objects.create(user=instance, name=f"{instance.first_name} {instance.last_name}", bp=BP.get_active(),
+                              confirmed=False)
+        return response


### PR DESCRIPTION
As part of the effort to automatically create and assign users, this PR creates a TL and connects it to the new user when accessing /lti/log

Contains and depends on #41 