### PR TITLE
Export Timetracking as PDF

### DIFF
--- a/bp/templates/bp/timetracking/timetracking_project_overview.html
+++ b/bp/templates/bp/timetracking/timetracking_project_overview.html
@@ -6,12 +6,27 @@
     <li class="breadcrumb-item active">{{ project.nr }}: {{ project.title }}</li>
 {% endblock %}
 
+{% block imports %}
+    <style>
+        @media only print {
+            body { visibility: hidden; }
+            .printthis { visibility: visible; }
+        }
+    </style>
+{% endblock %}
+
+
 {% block student_content %}
 {% block tl_content %}
 {% block orga_content %}
-    <h3 class="my-4">{{ project.nr }}: {{ project.title }}</h3>
-    <h4 class="mt-3">Überblick ({{ total_hours }}h)</h4>
-    {% include "bp/timetracking/render_timetracking_overview.html" with project=project timetable=timetable %}
+    <h3 class="my-4 printthis">{{ project.nr }}: {{ project.title }}</h3>
+    <div class="float-right mb-4">
+        <button class="btn btn-info" onclick="window.print()">Zeiterfassung für Moodle exportieren</button>
+    </div>
+    <h4 class="mt-3 printthis">Überblick ({{ total_hours }}h)</h4>
+    <div id="tt_table" class="printthis">
+        {% include "bp/timetracking/render_timetracking_overview.html" with project=project timetable=timetable %}
+    </div>
 {% endblock %}
 {% endblock %}
 {% endblock %}


### PR DESCRIPTION
Prints the project name, the title with total hours, and of course the entire table using the built-in print functionality
Technically, everyone can print the page, but ultimately only the students will use this functionality

Closes #50 