### PR TITLE
Add pretix link to project overview

### DIFF
--- a/bp/pretix.py
+++ b/bp/pretix.py
@@ -56,6 +56,18 @@ def load_pretix_single_entry(url):
 
     return json.loads(r.text)
 
+def get_pretix_projectinfo_url(project):
+    """
+    Get Pretix url to more infos on the project
+
+    :param project: project of interest
+    :type project: Project
+    :return: Pretix URL
+    :rtype: str
+    """
+    event_slug = project.bp.pretix_event_ag
+    order_id = project.order_id
+    return f"{settings.PRETIX_BASE_URL}control/event/{settings.PRETIX_ORGANIZER}/{event_slug}/orders/{order_id}"
 
 def pretix_url(endpoint, event_slug):
     """

--- a/bp/templates/bp/project.html
+++ b/bp/templates/bp/project.html
@@ -23,6 +23,9 @@
         <tr>
             <td>AG:</td><td><a href="mailto:{{ project.ag_mail }}">{{ project.ag }}&nbsp;{% fa5_icon "envelope" "far" %}</a></td>
         </tr>
+        <tr>
+            <td>Weitere Informationen:</td><td><a href={{ info_url }}>{{ info_url }}</a></td>
+        </tr>
         {% if user.is_staff and project.ag_points >= 0 %}
             <tr>
                 <td>Bewertung:</td><td><b>{{ project.ag_points }} Punkte</b><br><br>{{ project.ag_points_justification|linebreaks }}</td>

--- a/bp/views.py
+++ b/bp/views.py
@@ -19,6 +19,7 @@ from bp.grading.ag.views import ProjectGradesMixin
 
 from bp.forms import ProjectImportForm, StudentImportForm, TLLogForm, TLLogUpdateForm, LogReminderForm
 from bp.models import BP, Project, Student, TL, TLLog, OrgaLog
+from bp.pretix import get_pretix_projectinfo_url
 
 
 def error_400(request, exception):
@@ -80,6 +81,7 @@ class ProjectView(PermissionRequiredMixin, ProjectGradesMixin, DetailView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
+        context["info_url"] = get_pretix_projectinfo_url(context["project"])
         context["logs"] = context["project"].tllog_set.all().prefetch_related("current_problems")
         context["log_count"] = context["logs"].count()
         context["orga_logs"] = context["project"].orgalog_set.all().prefetch_related("current_problems")

--- a/bptool/settings.py
+++ b/bptool/settings.py
@@ -179,6 +179,12 @@ SESSION_ENGINE = "django.contrib.sessions.backends.signed_cookies"
 SESSION_COOKIE_SAMESITE = None
 SESSION_COOKIE_SECURE = True
 
+PRETIX_BASE_URL = "https://<your-hostname>/"
+PRETIX_ORGANIZER = "<organizer>"
+PRETIX_API_BASE_URL = f"{PRETIX_BASE_URL}api/v1/"
+PRETIX_API_ORGANIZER = PRETIX_ORGANIZER
+PRETIX_API_TOKEN = "<secret-api-token>"
+
 SEND_MAILS = True
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 


### PR DESCRIPTION
Each project is managed via pretix and has its own page there. That page includes more infos than the BP-tool provides and to some extend can provide

Also added default settings for pretix

Relevant for #18 