### PR TITLE
Improve structure of project details

### DIFF
--- a/bp/grading/ag/views.py
+++ b/bp/grading/ag/views.py
@@ -13,7 +13,8 @@ class ProjectByOrderIDMixin:
         return Project.objects.get(order_id=self.kwargs["order_id"])
 
 class ProjectGradesMixin:
-    def get_grading_context_data(self, context, project):
+    @staticmethod
+    def get_grading_context_data(context, project):
         beforedeadline = project.aggradebeforedeadline_set.all().order_by("-timestamp")
         afterdeadline = project.aggradeafterdeadline_set.all().order_by("-timestamp")
         context["gradings_before"] = beforedeadline
@@ -21,8 +22,9 @@ class ProjectGradesMixin:
         context["gradings_before_count"] = context["gradings_before"].count()
         context["gradings_after_count"] = context["gradings_after"].count()
         context["gradings_count"] = context["gradings_before_count"] + context["gradings_after_count"]
-        context["valid_grade_after"] = (project.ag_grade and project.ag_grade.pk) or 0
-        context["valid_grade_before"] = context["valid_grade_after"] or (beforedeadline.first() and beforedeadline.first().pk)
+        context["valid_grade_after"] = (project.ag_grade and project.ag_grade.pk) or None
+        context["valid_grade_before"] = None if (context["valid_grade_after"] or not beforedeadline.first()) \
+                                        else beforedeadline.first().pk
         return context
 
 class AGGradeView(ProjectByOrderIDMixin, ProjectGradesMixin, CreateView):

--- a/bp/templates/bp/project.html
+++ b/bp/templates/bp/project.html
@@ -1,6 +1,7 @@
 {% extends "bp/base.html" %}
 
 {% load fontawesome_5 %}
+{% load tags_bp %}
 
 {% block breadcrumbs %}
     <li class="breadcrumb-item"><a href="{% url "bp:index" %}">Übersicht</a></li>
@@ -12,75 +13,8 @@
 {% block content %}
     <h1>{{ project.nr }}: {{ project.title }}</h1>
 
-    <table class="table">
-        <tr>
-            <td>TL:</td><td>{% if project.tl %}<a href="{% url "bp:tl_detail" pk=project.tl.pk %}">{{ project.tl }}</a>{% else %}-{% endif %}</td>
-        </tr>
-        <tr>
-            <td>Mitglieder:</td><td><a href="mailto:{{ project.student_mail }}">{{ project.student_list }}&nbsp;{% fa5_icon "envelope" "far" %}</a><br>
-                                    {{ project.student_mail }}</td>
-        </tr>
-        <tr>
-            <td>AG:</td><td><a href="mailto:{{ project.ag_mail }}">{{ project.ag }}&nbsp;{% fa5_icon "envelope" "far" %}</a></td>
-        </tr>
-        <tr>
-            <td>Weitere Informationen:</td><td><a href={{ info_url }}>{{ info_url }}</a></td>
-        </tr>
-        {% if user.is_staff and project.ag_points >= 0 %}
-            <tr>
-                <td>Bewertung:</td><td><b>{{ project.ag_points }} Punkte</b><br><br>{{ project.ag_points_justification|linebreaks }}</td>
-            </tr>
-        {% endif %}
-        <tr>
-            <td>Gesamtstunden:</td><td><a href="{% url "bp:timetracking_project_overview" group=project.nr %}">{{ total_hours_spent }}</a></td>
-        </tr>
-    </table>
+    {% project_info_table %}
 
-    {% include "bp/render_all_gradings.html" %}
-
-    <h2>Orga-Logs ({{ orga_log_count }})</h2>
-
-    {% if orga_log_count > 0 %}
-        {% include "bp/render_orga_logs.html" with logs=orga_logs %}
-    {% else %}
-
-    {% endif %}
-
-    <h2>Logs ({{ log_count }})</h2>
-
-    {% if log_count > 0 %}
-        <canvas id="statusChart" width="100%" height="15vh" class="mb-5"></canvas>
-        <script>
-            const ctx = $('#statusChart');
-            const myChart = new Chart(ctx, {
-                type: 'line',
-                data: {
-                    datasets: [{
-                        label: 'status',
-                        data: {{project.status_json_string|safe}},
-                        backgroundColor: '#1F9BCF',
-                        borderColor: '#1F9BCF',
-                        borderWidth: 1
-                    }]
-                },
-                options: {
-                    scales: {
-                        y: {
-                            suggestedMin: -2,
-                            suggestedMax: 2
-                        }
-                    },
-                    plugins: {
-                        legend: {
-                            display: false
-                        }
-                    }
-                }
-            });
-            </script>
-        {% include "bp/render_logs.html" with logs=logs %}
-    {% else %}
-
-    {% endif %}
+    {% project_info_tabs %}
 
 {% endblock %}

--- a/bp/templates/bp/project_info_table.html
+++ b/bp/templates/bp/project_info_table.html
@@ -1,0 +1,25 @@
+{% load fontawesome_5 %}
+
+<table class="table">
+    <tr>
+        <td>TL:</td><td>{% if project.tl %}<a href="{% url "bp:tl_detail" pk=project.tl.pk %}">{{ project.tl }}</a>{% else %}-{% endif %}</td>
+    </tr>
+    <tr>
+        <td>Mitglieder:</td><td><a href="mailto:{{ project.student_mail }}">{{ project.student_list }}&nbsp;{% fa5_icon "envelope" "far" %}</a><br>
+                                {{ project.student_mail }}</td>
+    </tr>
+    <tr>
+        <td>AG:</td><td><a href="mailto:{{ project.ag_mail }}">{{ project.ag }}&nbsp;{% fa5_icon "envelope" "far" %}</a></td>
+    </tr>
+    <tr>
+        <td>Weitere Informationen:</td><td><a href={{ info_url }}>{{ info_url }}</a></td>
+    </tr>
+    {% if project.ag_points >= 0 %}
+        <tr>
+            <td>Bewertung:</td><td><b>{{ project.ag_points }} Punkte</b><br><br>{{ project.ag_points_justification|linebreaks }}</td>
+        </tr>
+    {% endif %}
+    <tr>
+        <td>Gesamtstunden:</td><td><a href="{% url "bp:timetracking_project_overview" group=project.nr %}">{{ total_hours_spent }}</a></td>
+    </tr>
+</table>

--- a/bp/templates/bp/project_info_tabs.html
+++ b/bp/templates/bp/project_info_tabs.html
@@ -1,0 +1,47 @@
+{% include "bp/render_all_gradings.html" %}
+
+<h2>Orga-Logs ({{ orga_log_count }})</h2>
+
+{% if orga_log_count > 0 %}
+    {% include "bp/render_orga_logs.html" with logs=orga_logs %}
+{% else %}
+
+{% endif %}
+
+<h2>Logs ({{ log_count }})</h2>
+
+{% if log_count > 0 %}
+    <canvas id="statusChart" width="100%" height="15vh" class="mb-5"></canvas>
+    <script>
+        const ctx = $('#statusChart');
+        const myChart = new Chart(ctx, {
+            type: 'line',
+            data: {
+                datasets: [{
+                    label: 'status',
+                    data: {{project.status_json_string|safe}},
+                    backgroundColor: '#1F9BCF',
+                    borderColor: '#1F9BCF',
+                    borderWidth: 1
+                }]
+            },
+            options: {
+                scales: {
+                    y: {
+                        suggestedMin: -2,
+                        suggestedMax: 2
+                    }
+                },
+                plugins: {
+                    legend: {
+                        display: false
+                    }
+                }
+            }
+        });
+        </script>
+    {% include "bp/render_logs.html" with logs=logs %}
+{% else %}
+
+{% endif %}
+

--- a/bp/views.py
+++ b/bp/views.py
@@ -19,7 +19,6 @@ from bp.grading.ag.views import ProjectGradesMixin
 
 from bp.forms import ProjectImportForm, StudentImportForm, TLLogForm, TLLogUpdateForm, LogReminderForm
 from bp.models import BP, Project, Student, TL, TLLog, OrgaLog
-from bp.pretix import get_pretix_projectinfo_url
 
 
 def error_400(request, exception):
@@ -78,17 +77,6 @@ class ProjectView(PermissionRequiredMixin, ProjectGradesMixin, DetailView):
     template_name = "bp/project.html"
     context_object_name = "project"
     permission_required = 'bp.view_project'
-
-    def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs)
-        context["info_url"] = get_pretix_projectinfo_url(context["project"])
-        context["logs"] = context["project"].tllog_set.all().prefetch_related("current_problems")
-        context["log_count"] = context["logs"].count()
-        context["orga_logs"] = context["project"].orgalog_set.all().prefetch_related("current_problems")
-        context["orga_log_count"] = context["orga_logs"].count()
-        context["total_hours_spent"] = self.get_object().total_hours
-        context = self.get_grading_context_data(context, context["project"])
-        return context
 
 
 class TLListView(PermissionRequiredMixin, FilterByActiveBPMixin, ListView):


### PR DESCRIPTION
The project details page takes infos from every subsystem in the BP-Tool. Therefore, it also depends on all of them

The project.html has two sections which are now defined in their own tags. Those tags create the necessary template context themselves using only the project