### PR TITLE
Dynamically create project info table

### DIFF
--- a/bp/templates/bp/project_info_table.html
+++ b/bp/templates/bp/project_info_table.html
@@ -1,31 +1,10 @@
 {% load fontawesome_5 %}
-{% load tags_project_info_table %}
+{% load tags_bp %}
 
 <table class="table">
-    {% comment The idea for this table is to eventually look like this: %}
     {% for info in infos %}
         <tr>
-            {% info %}
+            {% render info tags_project_info_table %}
         </tr>
     {% endfor %}
-    {% endcomment %}
-
-    <tr>
-        {% tl_info %}
-    </tr>
-    <tr>
-        {% member_info %}
-    </tr>
-    <tr>
-        {% ag_info %}
-    </tr>
-    <tr>
-        {% pretix_info %}
-    </tr>
-    <tr>
-        {% grade_info %}
-    </tr>
-    <tr>
-        {% hours_info %}
-    </tr>
 </table>

--- a/bp/templatetags/tags_bp.py
+++ b/bp/templatetags/tags_bp.py
@@ -6,6 +6,7 @@ from django.utils.safestring import mark_safe
 from bp.models import TLLog
 
 from bp.grading.ag.views import ProjectGradesMixin
+from .tags_project_info_table import ProjectInfoTable
 
 register = template.Library()
 
@@ -77,6 +78,7 @@ class RenderTagNode(template.Node):
 def project_info_table(context):
     return {
         'project' : context['project'],
+        'infos' : ProjectInfoTable.get_ordered_infos(),
     }
 
 @register.inclusion_tag('bp/project_info_tabs.html', takes_context=True)

--- a/bp/templatetags/tags_project_info_table.py
+++ b/bp/templatetags/tags_project_info_table.py
@@ -1,51 +1,95 @@
-from django import template
-from django.apps import apps
-from django.conf import settings
-from django.utils.safestring import mark_safe
+import heapq
 
-from bp.models import TLLog
+from django import template
 
 from bp.pretix import get_pretix_projectinfo_url
 
 register = template.Library()
 
-@register.inclusion_tag('bp/project_info_table_tl_info.html', takes_context=True)
-def tl_info(context):
+class ProjectInfoTable():
+    """
+            This class collects all info rows for the project info table.
+            Each row is defined using a template tag.
+
+            The tags are ordered by priority first and then name.
+              Lower value for priority means higher listing
+              Equal priority is sorted alphabetically
+    """
+    registered_rows = []
+
+    @staticmethod
+    def get_ordered_infos():
+        return map(lambda e: e[1], sorted(ProjectInfoTable.registered_rows))
+
+    @staticmethod
+    def register(template_name, *, priority):
+        '''
+            This decorator registers tags intended for the project info table.
+            Tags are registered as inclusion_tags and may take only one required argument
+            whose value is the project of interest.
+
+            Example Usage:
+            from . import ProjectInfoTable
+
+            @ProjectInfoTable.register('template.html', priority=1)
+            def creates_context_based_on_the_project(project):
+                return {'project' : project}
+
+            Result:
+            Registers a tag that renders template.html with the created context upon calling
+
+            :param template_name: name of the template which will be rendered by the inclusion_tag
+            :param priority: priority associated with the tag
+            :type priority: int
+            :return a decorator to register the tag in this tag set
+        '''
+        def create_and_register_tag(info_tag):
+            tag_name = info_tag.__name__
+
+            @register.inclusion_tag(template_name, takes_context=True, name=tag_name)
+            def new_tag(context):
+                return info_tag(context['project'])
+            heapq.heappush(ProjectInfoTable.registered_rows, (priority, tag_name))
+        return create_and_register_tag
+
+
+@ProjectInfoTable.register('bp/project_info_table_tl_info.html', priority=1)
+def tl_info(project):
     return {
-        'tl' : context['project'].tl,
+        'tl' : project.tl,
     }
 
-@register.inclusion_tag('bp/project_info_table_member_info.html', takes_context=True)
-def member_info(context):
+@ProjectInfoTable.register('bp/project_info_table_member_info.html', priority=2)
+def member_info(project):
     return {
-        'student_list'  : context['project'].student_list,
-        'student_mails' : context['project'].student_mail,
+        'student_list'  : project.student_list,
+        'student_mails' : project.student_mail,
     }
 
-@register.inclusion_tag('bp/project_info_table_ag_info.html', takes_context=True)
-def ag_info(context):
+@ProjectInfoTable.register('bp/project_info_table_ag_info.html', priority=3)
+def ag_info(project):
     return {
-        'ag'      : context['project'].ag,
-        'ag_mail' : context['project'].ag_mail,
+        'ag'      : project.ag,
+        'ag_mail' : project.ag_mail,
     }
 
-@register.inclusion_tag('bp/project_info_table_pretix_info.html', takes_context=True)
-def pretix_info(context):
+@ProjectInfoTable.register('bp/project_info_table_pretix_info.html', priority=4)
+def pretix_info(project):
     return {
-        'info_url' : get_pretix_projectinfo_url(context['project']),
+        'info_url' : get_pretix_projectinfo_url(project),
     }
 
-@register.inclusion_tag('bp/project_info_table_grade_info.html', takes_context=True)
-def grade_info(context):
+@ProjectInfoTable.register('bp/project_info_table_grade_info.html', priority=5)
+def grade_info(project):
     return {
-        'show_aggrade'            : context['project'].ag_points >= 0,
-        'ag_points'               : context['project'].ag_points,
-        'ag_points_justification' : context['project'].ag_points_justification,
+        'show_aggrade'            : project.ag_points >= 0,
+        'ag_points'               : project.ag_points,
+        'ag_points_justification' : project.ag_points_justification,
     }
 
-@register.inclusion_tag('bp/project_info_table_hours_info.html', takes_context=True)
-def hours_info(context):
+@ProjectInfoTable.register('bp/project_info_table_hours_info.html', priority=6)
+def hours_info(project):
     return {
-        'project'           : context['project'],
-        'total_hours_spent' : context['project'].total_hours,
+        'project'           : project,
+        'total_hours_spent' : project.total_hours,
     }


### PR DESCRIPTION
Further separates the project info from its visualization in the table by inverting the dependencies

As a rough structure, each row is defined separately by the user and then registered in the common ProjectInfosTable. 
The registered tags are retrieved from that class by the rendering logic in order to render each row.
A priority can be given to determine the order in which the elements should appear in the list

For rendering, a new tag render_tag is introduced that renders a tag given only its name and tag set as strings.

Depends on #65 