### PR TITLE
Make the details displayed on the project page fully dynamic

### DIFF
--- a/bp/templates/bp/project_info_misc_grading_content.html
+++ b/bp/templates/bp/project_info_misc_grading_content.html
@@ -1,0 +1,1 @@
+{% include "bp/render_gradings_tab.html" %}

--- a/bp/templates/bp/project_info_misc_grading_desc.html
+++ b/bp/templates/bp/project_info_misc_grading_desc.html
@@ -1,0 +1,1 @@
+Alle Bewertungen ({{ gradings_count }})

--- a/bp/templates/bp/project_info_misc_log_content.html
+++ b/bp/templates/bp/project_info_misc_log_content.html
@@ -1,0 +1,35 @@
+{% if log_count > 0 %}
+    <canvas id="statusChart" width="100%" height="15vh" class="mb-5"></canvas>
+    <script>
+        const ctx = $('#statusChart');
+        const myChart = new Chart(ctx, {
+            type: 'line',
+            data: {
+                datasets: [{
+                    label: 'status',
+                    data: {{status_data|safe}},
+                    backgroundColor: '#1F9BCF',
+                    borderColor: '#1F9BCF',
+                    borderWidth: 1
+                }]
+            },
+            options: {
+                scales: {
+                    y: {
+                        suggestedMin: -2,
+                        suggestedMax: 2
+                    }
+                },
+                plugins: {
+                    legend: {
+                        display: false
+                    }
+                }
+            }
+        });
+        </script>
+    {% include "bp/render_logs.html" with logs=logs %}
+{% else %}
+
+{% endif %}
+

--- a/bp/templates/bp/project_info_misc_log_desc.html
+++ b/bp/templates/bp/project_info_misc_log_desc.html
@@ -1,0 +1,1 @@
+Logs ({{ log_count }})

--- a/bp/templates/bp/project_info_misc_orgalog_content.html
+++ b/bp/templates/bp/project_info_misc_orgalog_content.html
@@ -1,0 +1,5 @@
+{% if orga_log_count > 0 %}
+    {% include "bp/render_orga_logs.html" with logs=orga_logs %}
+{% else %}
+
+{% endif %}

--- a/bp/templates/bp/project_info_misc_orgalog_desc.html
+++ b/bp/templates/bp/project_info_misc_orgalog_desc.html
@@ -1,0 +1,1 @@
+Orga-Logs ({{ orga_log_count }})

--- a/bp/templates/bp/project_info_table.html
+++ b/bp/templates/bp/project_info_table.html
@@ -1,31 +1,10 @@
 {% load fontawesome_5 %}
-{% load tags_project_info_table %}
+{% load tags_bp %}
 
 <table class="table">
-    {% comment The idea for this table is to eventually look like this: %}
     {% for info in infos %}
         <tr>
-            {% info %}
+            {% render info tags_project_info_table %}
         </tr>
     {% endfor %}
-    {% endcomment %}
-
-    <tr>
-        {% tl_info %}
-    </tr>
-    <tr>
-        {% member_info %}
-    </tr>
-    <tr>
-        {% ag_info %}
-    </tr>
-    <tr>
-        {% pretix_info %}
-    </tr>
-    <tr>
-        {% grade_info %}
-    </tr>
-    <tr>
-        {% hours_info %}
-    </tr>
 </table>

--- a/bp/templates/bp/project_info_tabs.html
+++ b/bp/templates/bp/project_info_tabs.html
@@ -1,44 +1,24 @@
 {% load tags_project_info_misc %}
+{% load tags_bp %}
 
 <ul class="nav nav-tabs">
-    <li class="nav-item">
-        <a class="nav-link active" data-toggle="tab"
-           href="#g_1">
-            {% log_description %}
-        </a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link " data-toggle="tab"
-           href="#g_2">
-            {% orgalog_description %}
-        </a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link " data-toggle="tab"
-           href="#g_3">
-            {% grading_description %}
-        </a>
-    </li>
+    {% for desc, content in infos %}
+	    <li class="nav-item">
+	        <a class="nav-link {% if forloop.first %}active{% endif %}" data-toggle="tab"
+	           href="#g_{{ forloop.counter }}">
+	            {% render desc tags_project_info_misc %}
+	        </a>
+	    </li>
+    {% endfor %}
 </ul>
 
 <div id="myTabContent" class="tab-content">
 
-    <div class="tab-pane fade active show" id="g_1">
-        <h3 class="my-4">{% log_description %}</h3>
+    {% for desc, content in infos %}
+	    <div class="tab-pane fade {% if forloop.first %}active show{% endif %}" id="g_{{ forloop.counter }}">
+	        <h3 class="my-4">{% render desc tags_project_info_misc %}</h3>
 
-        {% log_content %}
-    </div>
-
-    <div class="tab-pane fade" id="g_2">
-        <h3 class="my-4">{% orgalog_description %}</h3>
-
-        {% orgalog_content %}
-    </div>
-
-    <div class="tab-pane fade" id="g_3">
-        <h3 class="my-4">{% grading_description %}</h3>
-
-        {% grading_content %}
-    </div>
-
+	        {% render content tags_project_info_misc %}
+	    </div>
+    {% endfor %}
 </div>

--- a/bp/templates/bp/project_info_tabs.html
+++ b/bp/templates/bp/project_info_tabs.html
@@ -1,80 +1,44 @@
+{% load tags_project_info_misc %}
+
 <ul class="nav nav-tabs">
     <li class="nav-item">
         <a class="nav-link active" data-toggle="tab"
-           href="#g_logs">
-            Logs ({{ log_count }})
+           href="#g_1">
+            {% log_description %}
         </a>
     </li>
     <li class="nav-item">
         <a class="nav-link " data-toggle="tab"
-           href="#g_orgalogs">
-            Orga-Logs ({{ orga_log_count }})
+           href="#g_2">
+            {% orgalog_description %}
         </a>
     </li>
     <li class="nav-item">
         <a class="nav-link " data-toggle="tab"
-           href="#g_grades">
-            Alle Bewertungen ({{ gradings_count }})
+           href="#g_3">
+            {% grading_description %}
         </a>
     </li>
 </ul>
 
 <div id="myTabContent" class="tab-content">
 
-    <div class="tab-pane fade active show" id="g_logs">
-        <h3 class="my-4">Logs ({{ log_count }})</h3>
+    <div class="tab-pane fade active show" id="g_1">
+        <h3 class="my-4">{% log_description %}</h3>
 
-		{% if log_count > 0 %}
-		    <canvas id="statusChart" width="100%" height="15vh" class="mb-5"></canvas>
-		    <script>
-		        const ctx = $('#statusChart');
-		        const myChart = new Chart(ctx, {
-		            type: 'line',
-		            data: {
-		                datasets: [{
-		                    label: 'status',
-		                    data: {{project.status_json_string|safe}},
-		                    backgroundColor: '#1F9BCF',
-		                    borderColor: '#1F9BCF',
-		                    borderWidth: 1
-		                }]
-		            },
-		            options: {
-		                scales: {
-		                    y: {
-		                        suggestedMin: -2,
-		                        suggestedMax: 2
-		                    }
-		                },
-		                plugins: {
-		                    legend: {
-		                        display: false
-		                    }
-		                }
-		            }
-		        });
-		        </script>
-		    {% include "bp/render_logs.html" with logs=logs %}
-		{% else %}
-
-		{% endif %}
-
+        {% log_content %}
     </div>
 
-    <div class="tab-pane fade" id="g_orgalogs">
-		<h3 class="my-4">Orga-Logs ({{ orga_log_count }})</h3>
+    <div class="tab-pane fade" id="g_2">
+        <h3 class="my-4">{% orgalog_description %}</h3>
 
-		{% if orga_log_count > 0 %}
-		    {% include "bp/render_orga_logs.html" with logs=orga_logs %}
-		{% else %}
-
-		{% endif %}
+        {% orgalog_content %}
     </div>
 
-    <div class="tab-pane fade" id="g_grades">
-		<h3 class="my-4">Alle Bewertungen ({{ gradings_count }})</h3>
+    <div class="tab-pane fade" id="g_3">
+        <h3 class="my-4">{% grading_description %}</h3>
 
-		{% include "bp/render_gradings_tab.html" %}
+        {% grading_content %}
     </div>
 
 </div>

--- a/bp/templatetags/tags_bp.py
+++ b/bp/templatetags/tags_bp.py
@@ -6,6 +6,7 @@ from django.utils.safestring import mark_safe
 from bp.models import TLLog
 
 from .tags_project_info_table import ProjectInfoTable
+from .tags_project_info_misc import ProjectInfoTabs
 
 register = template.Library()
 
@@ -84,4 +85,5 @@ def project_info_table(context):
 def project_info_tabs(context):
     return {
         'project' : context['project'],
+        'infos' : ProjectInfoTabs.get_ordered_infos(),
     }

--- a/bp/templatetags/tags_bp.py
+++ b/bp/templatetags/tags_bp.py
@@ -6,6 +6,7 @@ from django.utils.safestring import mark_safe
 from bp.models import TLLog
 
 from bp.grading.ag.views import ProjectGradesMixin
+from .tags_project_info_table import ProjectInfoTable
 
 register = template.Library()
 
@@ -77,6 +78,7 @@ class RenderTagNode(template.Node):
 def project_info_table(context):
     return {
         'project' : context['project'],
+        'infos' : ProjectInfoTable.get_ordered_infos(),
     }
 
 @register.inclusion_tag('bp/project_info_tabs.html', takes_context=True)

--- a/bp/templatetags/tags_bp.py
+++ b/bp/templatetags/tags_bp.py
@@ -5,7 +5,6 @@ from django.utils.safestring import mark_safe
 
 from bp.models import TLLog
 
-from bp.grading.ag.views import ProjectGradesMixin
 from .tags_project_info_table import ProjectInfoTable
 
 register = template.Library()
@@ -83,15 +82,6 @@ def project_info_table(context):
 
 @register.inclusion_tag('bp/project_info_tabs.html', takes_context=True)
 def project_info_tabs(context):
-    tab_context = dict()
-    tab_context["project"] = context["project"]
-
-    tab_context["logs"] = context["project"].tllog_set.all().prefetch_related("current_problems")
-    tab_context["log_count"] = tab_context["logs"].count()
-
-    tab_context["orga_logs"] = context["project"].orgalog_set.all().prefetch_related("current_problems")
-    tab_context["orga_log_count"] = tab_context["orga_logs"].count()
-
-    tab_context = ProjectGradesMixin.get_grading_context_data(tab_context, context["project"])
-
-    return tab_context
+    return {
+        'project' : context['project'],
+    }

--- a/bp/templatetags/tags_project_info_misc.py
+++ b/bp/templatetags/tags_project_info_misc.py
@@ -1,3 +1,5 @@
+import heapq
+
 from django import template
 
 from bp.grading.ag.views import ProjectGradesMixin
@@ -5,39 +7,132 @@ from bp.grading.ag.views import ProjectGradesMixin
 register = template.Library()
 
 
-@register.inclusion_tag('bp/project_info_misc_log_desc.html', takes_context=True)
-def log_description(context):
+class ProjectInfoTabTags():
+    """
+        This class registers tags intended for the project info tabs.
+        Tags are registered as inclusion_tags and may take only one required argument
+        whose value is the project of interest.
+        Each tab has a description tag and a content tab who must both exist before
+        the tags are registered
+
+        Example Usage:
+
+        from . import ProjectInfoTabTags
+        info_tab = ProjectInfoTabTags(priority=1)
+
+        @info_tab.register_description('template_desc.html')
+        def creates_description_context_based_on_the_project(project):
+            return {'project' : project}
+
+        @info_tab.register_content('template_content.html')
+        def creates_content_context_based_on_the_project(project):
+            return {'project' : project}
+
+        Result:
+        Registers two tags that render their templates with the created context upon calling
+        Tags can be retrieved via ProjectInfoTabs.get_ordered_infos()
+    """
+    def __init__(self, *, priority):
+        self.priority = priority
+        self.description = None
+        self.content = None
+
+    def register_if_available(self):
+        if self.description and self.content:
+            ProjectInfoTabs.create_and_register_tags(self.description, self.content, priority=self.priority)
+
+    def register_description(self, template_name):
+        def create_and_register_tag(info_tag):
+            self.description = (info_tag, template_name)
+            self.register_if_available()
+            return info_tag
+        return create_and_register_tag
+
+    def register_content(self, template_name):
+        def create_and_register_tag(info_tag):
+            self.content = (info_tag, template_name)
+            self.register_if_available()
+            return info_tag
+        return create_and_register_tag
+
+
+class ProjectInfoTabs():
+    """
+        This class collects the descriptions and the content for the project info tabs.
+        Each tab is defined using two template tags, one for the description and one for the content.
+        The tags are ordered by priority first and then name.
+          Lower value for priority means higher listing (further to the left)
+          Equal priority is sorted alphabetically
+    """
+    registered_tabs = []
+
+    @staticmethod
+    def get_ordered_infos():
+        return list(map(lambda e: e[1], sorted(ProjectInfoTabs.registered_tabs)))
+
+    @staticmethod
+    def create_and_register_tags(*info_tags, priority):
+        """
+            Registers a set of tags who are used simultaneously.
+            Each argument must be of the form
+            (info_tag, template_name)
+
+            :param info_tags: tags to be registered
+            :type info_tags: list of (info_tag, template_name)
+            :param priority: priority associated with the tags
+            :type priority: int
+            :return None
+        """
+        tag_names = list(map(lambda tag: tag[0].__name__, info_tags))
+        for (info_tag, template_name), tag_name in zip(info_tags, tag_names):
+
+            @register.inclusion_tag(template_name, takes_context=True, name=tag_name)
+            def new_tag(context):
+                return info_tag(context['project'])
+        heapq.heappush(ProjectInfoTabs.registered_tabs, (priority, tag_names))
+
+
+log_tab = ProjectInfoTabTags(priority=1)
+
+@log_tab.register_description('bp/project_info_misc_log_desc.html')
+def log_description(project):
     return {
-        'log_count' : context['project'].tllog_set.all().count(),
+        'log_count' : project.tllog_set.all().count(),
     }
 
-@register.inclusion_tag('bp/project_info_misc_log_content.html', takes_context=True)
-def log_content(context):
+@log_tab.register_content('bp/project_info_misc_log_content.html')
+def log_content(project):
     return {
-        'status_data' : context['project'].status_json_string,
-        'logs'        : context['project'].tllog_set.all(),
-        'log_count'   : context['project'].tllog_set.all().count(),
+        'status_data' : project.status_json_string,
+        'logs'        : project.tllog_set.all(),
+        'log_count'   : project.tllog_set.all().count(),
     }
 
-@register.inclusion_tag('bp/project_info_misc_orgalog_desc.html', takes_context=True)
-def orgalog_description(context):
+
+orgalog_tab = ProjectInfoTabTags(priority=2)
+
+@orgalog_tab.register_description('bp/project_info_misc_orgalog_desc.html')
+def orgalog_description(project):
     return {
-        'orga_log_count' : context['project'].orgalog_set.all().count(),
+        'orga_log_count' : project.orgalog_set.all().count(),
     }
 
-@register.inclusion_tag('bp/project_info_misc_orgalog_content.html', takes_context=True)
-def orgalog_content(context):
+@orgalog_tab.register_content('bp/project_info_misc_orgalog_content.html')
+def orgalog_content(project):
     return {
-        'orga_logs'        : context['project'].orgalog_set.all(),
-        'orga_log_count'   : context['project'].orgalog_set.all().count(),
+        'orga_logs'      : project.orgalog_set.all(),
+        'orga_log_count' : project.orgalog_set.all().count(),
     }
 
-@register.inclusion_tag('bp/project_info_misc_grading_desc.html', takes_context=True)
-def grading_description(context):
-    tab_context = {'project' : context['project']}
-    return ProjectGradesMixin.get_grading_context_data(tab_context, context['project'])
 
-@register.inclusion_tag('bp/project_info_misc_grading_content.html', takes_context=True)
-def grading_content(context):
-    tab_context = {'project' : context['project']}
-    return ProjectGradesMixin.get_grading_context_data(tab_context, context['project'])
+grading_tab = ProjectInfoTabTags(priority=3)
+
+@grading_tab.register_description('bp/project_info_misc_grading_desc.html')
+def grading_description(project):
+    tab_context = {'project' : project}
+    return ProjectGradesMixin.get_grading_context_data(tab_context, project)
+
+@grading_tab.register_content('bp/project_info_misc_grading_content.html')
+def grading_content(project):
+    tab_context = {'project' : project}
+    return ProjectGradesMixin.get_grading_context_data(tab_context, project)

--- a/bp/templatetags/tags_project_info_misc.py
+++ b/bp/templatetags/tags_project_info_misc.py
@@ -1,0 +1,43 @@
+from django import template
+
+from bp.grading.ag.views import ProjectGradesMixin
+
+register = template.Library()
+
+
+@register.inclusion_tag('bp/project_info_misc_log_desc.html', takes_context=True)
+def log_description(context):
+    return {
+        'log_count' : context['project'].tllog_set.all().count(),
+    }
+
+@register.inclusion_tag('bp/project_info_misc_log_content.html', takes_context=True)
+def log_content(context):
+    return {
+        'status_data' : context['project'].status_json_string,
+        'logs'        : context['project'].tllog_set.all(),
+        'log_count'   : context['project'].tllog_set.all().count(),
+    }
+
+@register.inclusion_tag('bp/project_info_misc_orgalog_desc.html', takes_context=True)
+def orgalog_description(context):
+    return {
+        'orga_log_count' : context['project'].orgalog_set.all().count(),
+    }
+
+@register.inclusion_tag('bp/project_info_misc_orgalog_content.html', takes_context=True)
+def orgalog_content(context):
+    return {
+        'orga_logs'        : context['project'].orgalog_set.all(),
+        'orga_log_count'   : context['project'].orgalog_set.all().count(),
+    }
+
+@register.inclusion_tag('bp/project_info_misc_grading_desc.html', takes_context=True)
+def grading_description(context):
+    tab_context = {'project' : context['project']}
+    return ProjectGradesMixin.get_grading_context_data(tab_context, context['project'])
+
+@register.inclusion_tag('bp/project_info_misc_grading_content.html', takes_context=True)
+def grading_content(context):
+    tab_context = {'project' : context['project']}
+    return ProjectGradesMixin.get_grading_context_data(tab_context, context['project'])

--- a/bp/templatetags/tags_project_info_table.py
+++ b/bp/templatetags/tags_project_info_table.py
@@ -1,51 +1,95 @@
-from django import template
-from django.apps import apps
-from django.conf import settings
-from django.utils.safestring import mark_safe
+import heapq
 
-from bp.models import TLLog
+from django import template
 
 from bp.pretix import get_pretix_projectinfo_url
 
 register = template.Library()
 
-@register.inclusion_tag('bp/project_info_table_tl_info.html', takes_context=True)
-def tl_info(context):
+class ProjectInfoTable():
+    """
+            This class collects all info rows for the project info table.
+            Each row is defined using a template tag.
+
+            The tags are ordered by priority first and then name.
+              Lower value for priority means higher listing
+              Equal priority is sorted alphabetically
+    """
+    registered_rows = []
+
+    @staticmethod
+    def get_ordered_infos():
+        return map(lambda e: e[1], sorted(ProjectInfoTable.registered_rows))
+
+    @staticmethod
+    def register(template_name, *, priority):
+        '''
+            This decorator registers tags intended for the project info table.
+            Tags are registered as inclusion_tags and may take only one required argument
+            whose value is the project of interest.
+
+            Example Usage:
+            from . import ProjectInfoTable
+
+            @ProjectInfoTable.register('template.html', priority=1)
+            def creates_context_based_on_the_project(project):
+                return {'project' : project}
+
+            Result:
+            Registers a tag that renders template.html with the created context upon calling
+
+            :param template_name: name of the template which will be rendered by the inclusion_tag
+            :param priority: priority associated with the tag
+            :type priority: int
+            :return a decorator to register the tag in this tag set
+        '''
+        def create_and_register_tag(info_tag):
+            tag_name = info_tag.__name__
+
+            @register.inclusion_tag(template_name, takes_context=True, name=tag_name)
+            def new_tag(context):
+                return info_tag(context['project'])
+            heapq.heappush(ProjectInfoTable.registered_rows, (priority, tag_name))
+        return create_and_register_tag
+
+
+@ProjectInfoTable.register('bp/project_info_table_tl_info.html', priority=1)
+def tl_info(project):
     return {
-        'tl' : context['project'].tl,
+        'tl' : project.tl,
     }
 
-@register.inclusion_tag('bp/project_info_table_member_info.html', takes_context=True)
-def member_info(context):
+@ProjectInfoTable.register('bp/project_info_table_member_info.html', priority=2)
+def member_info(project):
     return {
-        'student_list'  : context['project'].student_list,
-        'student_mails' : context['project'].student_mail,
+        'student_list'  : project.student_list,
+        'student_mails' : project.student_mail,
     }
 
-@register.inclusion_tag('bp/project_info_table_ag_info.html', takes_context=True)
-def ag_info(context):
+@ProjectInfoTable.register('bp/project_info_table_ag_info.html', priority=3)
+def ag_info(project):
     return {
-        'ag'      : context['project'].ag,
-        'ag_mail' : context['project'].ag_mail,
+        'ag'      : project.ag,
+        'ag_mail' : project.ag_mail,
     }
 
-@register.inclusion_tag('bp/project_info_table_pretix_info.html', takes_context=True)
-def pretix_info(context):
+@ProjectInfoTable.register('bp/project_info_table_pretix_info.html', priority=4)
+def pretix_info(project):
     return {
-        'info_url' : get_pretix_projectinfo_url(context['project']),
+        'info_url' : get_pretix_projectinfo_url(project),
     }
 
-@register.inclusion_tag('bp/project_info_table_grade_info.html', takes_context=True)
-def grade_info(context):
+@ProjectInfoTable.register('bp/project_info_table_grade_info.html', priority=5)
+def grade_info(project):
     return {
-        'show_aggrade'            : context['project'].ag_points >= 0,
-        'ag_points'               : context['project'].ag_points,
-        'ag_points_justification' : context['project'].ag_points_justification,
+        'show_aggrade'            : project.ag_points >= 0,
+        'ag_points'               : project.ag_points,
+        'ag_points_justification' : project.ag_points_justification,
     }
 
-@register.inclusion_tag('bp/project_info_table_hours_info.html', takes_context=True)
-def hours_info(context):
+@ProjectInfoTable.register('bp/project_info_table_hours_info.html', priority=6)
+def hours_info(project):
     return {
-        'project'           : context['project'],
-        'total_hours_spent' : context['project'].total_hours,
+        'project'           : project,
+        'total_hours_spent' : project.total_hours,
     }


### PR DESCRIPTION
The project details page contains many infos which depend on various subsystems. Instead of hardcoding the existence of them, make it possible to register a table entry or a tab on which to display that information and let the subsystems deal with the visual and logical presentation of the data.

Replaces/Contains:
#66, #68, #69