### PR TITLE
Put timetracking diagrams into own tab

### DIFF
--- a/bp/templates/bp/timetracking/timetracking_project_overview.html
+++ b/bp/templates/bp/timetracking/timetracking_project_overview.html
@@ -20,45 +20,67 @@
 {% block tl_content %}
 {% block orga_content %}
     <h3 class="my-4 printthis">{{ project.nr }}: {{ project.title }}</h3>
-    <div class="float-right mb-4">
-        <button class="btn btn-info" onclick="window.print()">Zeiterfassung für Moodle exportieren</button>
-    </div>
-    <h4 class="mt-3 printthis">Überblick ({{ total_hours }}h / {{ project.expected_hours }}h)</h4>
+<ul class="nav nav-tabs">
+	    <li class="nav-item">
+	        <a class="nav-link active" data-toggle="tab"
+	           href="#g_1">
+	            Überblick
+	        </a>
+	    </li>
+	    <li class="nav-item">
+	        <a class="nav-link" data-toggle="tab"
+	           href="#g_2">
+	            Diagramme
+	        </a>
+	    </li>
+</ul>
 
-    <br>
-    Zeitaufwand nach Intervall (Stunden pro Tag)
-    <canvas id="statusChart" width="100%" height="15vh" class="mb-5"></canvas>
-    <script>
-        const ctx = $('#statusChart');
-        const myChart = new Chart(ctx, {
-            type: 'line',
-            data: {
-                datasets: [{
-                    label: 'Normalised hours in interval',
-                    data: {{hours_per_interval|safe}},
-                    backgroundColor: '#1F9BCF',
-                    borderColor: '#1F9BCF',
-                    borderWidth: 1
-                }]
-            },
-            options: {
-                scales: {
-                    y: {
-                        suggestedMin: 0,
-                        suggestedMax: 8
-                    }
-                },
-                plugins: {
-                    legend: {
-                        display: false
-                    }
-                }
-            }
-        });
-    </script>
-    <div id="tt_table" class="printthis">
-        {% include "bp/timetracking/render_timetracking_overview.html" with project=project timetable=timetable %}
-    </div>
+<div id="myTabContent" class="tab-content">
+
+	    <div class="tab-pane fade active show" id="g_1">
+		    <div class="float-right mb-4">
+		        <button class="btn btn-info" onclick="window.print()">Zeiterfassung für Moodle exportieren</button>
+		    </div>
+		    <h4 class="mt-3 printthis">Überblick ({{ total_hours }}h / {{ project.expected_hours }}h)</h4>
+		    <div id="tt_table" class="printthis">
+		        {% include "bp/timetracking/render_timetracking_overview.html" with project=project timetable=timetable %}
+		    </div>
+	    </div>
+	    <div class="tab-pane fade" id="g_2">
+	        <br>
+		    Zeitaufwand nach Intervall (Stunden pro Tag)
+		    <canvas id="statusChart" width="100%" height="15vh" class="mb-5"></canvas>
+		    <script>
+		        const ctx = $('#statusChart');
+		        const myChart = new Chart(ctx, {
+		            type: 'line',
+		            data: {
+		                datasets: [{
+		                    label: 'Normalised hours in interval',
+		                    data: {{hours_per_interval|safe}},
+		                    backgroundColor: '#1F9BCF',
+		                    borderColor: '#1F9BCF',
+		                    borderWidth: 1
+		                }]
+		            },
+		            options: {
+		                scales: {
+		                    y: {
+		                        suggestedMin: 0,
+		                        suggestedMax: 8
+		                    }
+		                },
+		                plugins: {
+		                    legend: {
+		                        display: false
+		                    }
+		                }
+		            }
+		        });
+		    </script>
+	    </div>
+</div>
+
 {% endblock %}
 {% endblock %}
 {% endblock %}


### PR DESCRIPTION
The tt project overview page displays a diagram for informational purposes. This diagram is located above the table for tt. This location poses several problems:
1. The Moodle export PDF has a blank void where the diagram would be (it's not visible, as intended).
2. Adding more diagrams pushes the table further down, but the table is the main reference, so should be at the top.

Both issues can be solved by moving this and future diagrams into their own tab.

Otherwise, no behaviour has changed.