### PR TITLE
Fix 404 when new BP is active

### DIFF
--- a/bp/roles.py
+++ b/bp/roles.py
@@ -1,4 +1,4 @@
-
+from bp.models import BP
 
 def is_tl(user):
     return hasattr(user, 'tl')
@@ -24,3 +24,12 @@ def is_neither_tl_nor_student_of_group(group, user):
     if is_student(user) and is_student_of_group(group, user):
         return False
     return True
+
+def get_bp_of_user(user):
+    if is_tl(user):
+        return user.tl.bp
+    if is_student(user):
+        return user.student.bp
+    if is_orga(user):
+        return BP.get_active()
+    return None

--- a/bp/timetracking/views.py
+++ b/bp/timetracking/views.py
@@ -13,6 +13,7 @@ from django.views.generic import TemplateView, DetailView, CreateView, FormView,
 
 from bp.models import BP, Project, Student
 from bp.roles import is_tl, is_student, is_orga, is_tl_or_student, is_tl_of_group, is_student_of_group, is_neither_tl_nor_student_of_group
+from bp.roles import get_bp_of_user
 
 from .forms import TimeIntervalForm, TimeIntervalGenerationForm, TimeIntervalUpdateForm, \
     TimeIntervalEntryForm, TLTimeIntervalEntryCorrectionForm
@@ -21,7 +22,7 @@ from .models import TimeInterval, TimeTrackingEntry, TimeSpentCategory
 
 class ProjectByRequestMixin:
     def get_project_by_request(self, request):
-        return get_object_or_404(Project, nr=self.kwargs.get("group", -1), bp=BP.get_active())
+        return get_object_or_404(Project, nr=self.kwargs.get("group", -1), bp=get_bp_of_user(request.user))
 
 class TimeIntervalByRequestMixin:
     def get_interval_by_request(self, request):

--- a/bp/tllogs/tl/mixins.py
+++ b/bp/tllogs/tl/mixins.py
@@ -1,7 +1,8 @@
 from django.shortcuts import get_object_or_404
 
 from bp.models import BP, Project
+from bp.roles import get_bp_of_user
 
 class ProjectByRequestMixin:
     def get_project_by_request(self, request):
-        return get_object_or_404(Project, nr=self.kwargs.get("group", -1), bp=BP.get_active())
+        return get_object_or_404(Project, nr=self.kwargs.get("group", -1), bp=get_bp_of_user(request.user))


### PR DESCRIPTION
Since the access control only checked for the project in the active BP, the old projects couldn't be accessed anymore once their BP wasn't active anymore.

With this fix, the access control always uses the BP of the registered user, so they can always access their project as long as it actually exists; after that, they will once again get a 404.