### PR TITLE
Avoid unnecessary checks in LTI for assigned users

### DIFF
--- a/bp/roles.py
+++ b/bp/roles.py
@@ -33,3 +33,6 @@ def get_bp_of_user(user):
     if is_orga(user):
         return BP.get_active()
     return None
+
+def has_role(user):
+    return is_orga(user) or is_tl(user) or is_student(user)

--- a/bptool/lti/views.py
+++ b/bptool/lti/views.py
@@ -2,6 +2,7 @@ from django.contrib import messages
 from django.views.decorators.csrf import csrf_exempt
 from lti_provider.views import LTIRoutingView
 
+from bp.roles import has_role
 from bp.views import BP, TL, Student
 
 
@@ -11,9 +12,10 @@ class TLRoutingView(LTIRoutingView):
         response = super().dispatch(request, *args, **kwargs)
         # Login happens in dispatch above
         instance = request.user
-        if instance and not TL.objects.filter(user=instance).first():
-            TL.objects.create(user=instance, name=f"{instance.first_name} {instance.last_name}", bp=BP.get_active(),
-                              confirmed=False)
+        if instance and not has_role(instance):
+            if not TL.objects.filter(user=instance).first():
+                TL.objects.create(user=instance, name=f"{instance.first_name} {instance.last_name}", bp=BP.get_active(),
+                                  confirmed=False)
         return response
 
 
@@ -23,11 +25,12 @@ class StudentRoutingView(LTIRoutingView):
         response = super().dispatch(request, *args, **kwargs)
         # Login happens in dispatch above
         instance = request.user
-        if instance and instance.email and not Student.objects.filter(user=instance).first():
-            associatedStudent = Student.objects.filter(mail=instance.email, bp=BP.get_active()).first()
-            if associatedStudent:
-                associatedStudent.user = instance
-                associatedStudent.save()
-            else:
-                messages.add_message(self.request, messages.WARNING, "E-Mail-Addresse nicht gefunden. Bitte wende dich per Mail an die Veranstalter unter bp@cs.tu-darmstadt.de.")
+        if instance and not has_role(instance):
+            if instance.email and not Student.objects.filter(user=instance).first():
+                associatedStudent = Student.objects.filter(mail=instance.email, bp=BP.get_active()).first()
+                if associatedStudent:
+                    associatedStudent.user = instance
+                    associatedStudent.save()
+                else:
+                    messages.add_message(self.request, messages.WARNING, "E-Mail-Addresse nicht gefunden. Bitte wende dich per Mail an die Veranstalter unter bp@cs.tu-darmstadt.de.")
         return response


### PR DESCRIPTION
If a user already has a role, then they can't logically have another. Therefore, only try to assign a role to users who don't have one.

Also solves the issue of forwarding, since Orga members are redirected to the index page by the access control system (if they aren't TLs)

Closes #83 