### PR TITLE
Time measurement bug

### DIFF
--- a/bp/templates/bp/timetracking/timetracking_interval_create.html
+++ b/bp/templates/bp/timetracking/timetracking_interval_create.html
@@ -12,7 +12,7 @@
 {% endblock %}
 
 {% block tl_content %}
-    <h3 class="my-4">{{ project.nr }}: {{ project.title }}</h3>
+    <h4 class="my-4">{{ project.nr }}: {{ project.title }} - Zeitintervall erstellen</h4>
     <turbo-frame id="form">
         <form method="POST" class="post-form">{% csrf_token %}
             {% bootstrap_form form %}

--- a/bp/templates/bp/timetracking/timetracking_interval_create_update.html
+++ b/bp/templates/bp/timetracking/timetracking_interval_create_update.html
@@ -3,16 +3,25 @@
 {% load bootstrap4 %}
 {% load fontawesome_5 %}
 
-{% block tl_content %}
-    <p>Zeitintervall anzeigen und eintragen:</p>
+{% block breadcrumbs %}
+    <li class="breadcrumb-item"><a href="{% url "bp:index" %}">Übersicht</a></li>
+    <li class="breadcrumb-item"><a href="{% url "bp:timetracking_tl_start" %}">Zeiterfassung</a></li>
+    <li class="breadcrumb-item"><a href="{% url "bp:timetracking_project_overview" group=project.nr %}">{{ project.nr }}: {{ project.title }}</a></li>
+    <li class="breadcrumb-item"><a href="{% url "bp:timetracking_intervals" group=project.nr %}">Intervallverwaltung</a></li>
+    <li class="breadcrumb-item active">Intervall bearbeiten</li>
+{% endblock %}
 
+{% block tl_content %}
+    <h4 class="my-4">{{ project.nr }}: {{ project.title }} - Zeitintervall bearbeiten</h4>
     <form method="POST" class="post-form">{% csrf_token %}
         {% bootstrap_form form %}
         {% buttons %}
             <button type="submit" class="save btn btn-primary float-right">
                 {% fa5_icon "check" 'fas' %} Speichern
             </button>
-            <a href="{% url "bp:timetracking_intervals" timeinterval.group.nr %}" class="btn btn-warning float-left">Abbrechen</a>
+            <a href="{% url "bp:timetracking_intervals" timeinterval.group.nr %}" class="btn btn-warning float-left">
+                Abbrechen
+            </a>
         {% endbuttons %}
     </form>
 {% endblock %}

--- a/bp/timetracking/forms.py
+++ b/bp/timetracking/forms.py
@@ -130,6 +130,20 @@ class TimeIntervalUpdateForm(forms.ModelForm):
         model = TimeInterval
         fields = ['name', 'start', 'end']
 
+        widgets = {
+            'start': forms.DateInput(attrs={'type': 'date'}, format='%Y-%m-%d'),
+            'end': forms.DateInput(attrs={'type': 'date'}, format='%Y-%m-%d'),
+        }
+
+    def clean(self):
+        cleaned_data = super().clean()
+
+        if cleaned_data.get('end', None) and cleaned_data.get('start', None):
+            if cleaned_data['end'] < cleaned_data['start']:
+                self.add_error('end', "Ende muss später als Beginn sein")
+
+        return cleaned_data
+
 class TimeIntervalEntryForm(forms.ModelForm):
     class Meta:
         model = TimeTrackingEntry

--- a/bp/timetracking/views.py
+++ b/bp/timetracking/views.py
@@ -165,7 +165,7 @@ class TimetrackingIntervalsCreateView(ProjectByGroupMixin, LoginRequiredMixin, C
         if not is_tl(request.user):
             return redirect("bp:index")
         if not is_tl_of_group(project, request.user):
-            messages.add_message(request, messages.WARNING, "Du darfst für diese Gruppe keine Intervalle anlegen")
+            messages.add_message(request, messages.WARNING, "Du darfst für diese Gruppe keine Intervalle anlegen.")
             return redirect("bp:timetracking_tl_start")
         return super().get(request, *args, **kwargs)
 
@@ -231,9 +231,24 @@ class TimetrackingIntervalUpdateView(ProjectByRequestMixin, LoginRequiredMixin, 
     template_name = "bp/timetracking/timetracking_interval_create_update.html"
     context_object_name = "timeinterval"
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        project_nr = self.get_object()._meta.get_field("group").value_from_object(self.get_object())
+        context["project"] = BP.get_active().project_set.filter(nr=project_nr).first()
+        return context
+
     def get_success_url(self):
         messages.add_message(self.request, messages.SUCCESS, "Intervall aktualisiert")
         return reverse_lazy('bp:timetracking_intervals', kwargs={'group' : self.get_project_by_request(self.request).nr})
+
+    def get(self, request, *args, **kwargs):
+        project = self.get_project_by_request(request)
+        if not is_tl(request.user):
+            return redirect("bp:index")
+        if not is_tl_of_group(project, request.user):
+            messages.add_message(request, messages.WARNING, "Du darfst für diese Gruppe keine Intervalle bearbeiten.")
+            return redirect("bp:timetracking_tl_start")
+        return super().get(request, *args, **kwargs)
 
 class TimetrackingIntervalDeleteView(ProjectByRequestMixin, OnlyOwnEmptyTimeIntervalsMixin, LoginRequiredMixin, DeleteView):
     model = TimeInterval


### PR DESCRIPTION
- fixed bug, where it was possible to set a start date ahead of end date when editing an interval
- added datepicker to page "Intervall bearbeiten"
- fixed a bug, where students/tls were able to call a page they shouldn't be able to call
- added breadcrumbs navigation to page "Intervall bearbeiten"